### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/pybal/config.py
+++ b/pybal/config.py
@@ -31,7 +31,7 @@ class ConfigurationObserver(object):
         for subclass in get_subclasses(cls):
             if configUrl.startswith(subclass.urlScheme):
                 return subclass(coordinator, configUrl)
-        raise PyBalConfigurationError('No handler for URL "%s"' % configUrl)
+        raise PyBalConfigurationError('No handler for URL "{0!s}"'.format(configUrl))
 
 
 class FileConfigurationObserver(ConfigurationObserver):
@@ -103,7 +103,7 @@ class FileConfigurationObserver(ConfigurationObserver):
                 # We catch exceptions here (rather than simply allow them to
                 # bubble up to FileConfigurationObserver.logError) because we
                 # want to try and parse as much of the file as we can.
-                log.err(ex, 'Bad configuration line: %s' % line)
+                log.err(ex, 'Bad configuration line: {0!s}'.format(line))
                 continue
         return config
 

--- a/pybal/etcd.py
+++ b/pybal/etcd.py
@@ -82,8 +82,7 @@ class EtcdClient(HTTPClient):
 
     def timeout(self):
         err = defer.TimeoutError(
-            'Retrieving key %s from %s took longer than %s seconds.' %
-            (self.factory.key, self.factory.host, self.factory.timeout))
+            'Retrieving key {0!s} from {1!s} took longer than {2!s} seconds.'.format(self.factory.key, self.factory.host, self.factory.timeout))
         self.factory.onFailure(err)
         self.transport.loseConnection()
 
@@ -118,12 +117,12 @@ class EtcdConfigurationObserver(ConfigurationObserver, HTTPClientFactory):
         return parsed.hostname, parsed.port or 2379, parsed.path
 
     def getPath(self):
-        path = '/v2/keys/%s' % self.key.lstrip('/')
+        path = '/v2/keys/{0!s}'.format(self.key.lstrip('/'))
         params = {'recursive': 'true'}
         if self.waitIndex is not None:
             params['waitIndex'] = self.waitIndex
             params['wait'] = 'true'
-        path = '%s?%s' % (path, urllib.urlencode(params))
+        path = '{0!s}?{1!s}'.format(path, urllib.urlencode(params))
         return path
 
     def clientConnectionFailed(self, connector, reason):
@@ -163,4 +162,4 @@ class EtcdConfigurationObserver(ConfigurationObserver, HTTPClientFactory):
             self.lastConfig = config
 
     def onFailure(self, reason):
-        log.error('failed: %s' % reason)
+        log.error('failed: {0!s}'.format(reason))

--- a/pybal/instrumentation.py
+++ b/pybal/instrumentation.py
@@ -63,13 +63,13 @@ class Alerts(Resource):
             total = len(crd.servers)
             if pooledDown:
                 slist = ", ".join([s.host for s in crd.pooledDownServers])
-                critPools[pool] = "Servers %s are marked down but pooled" % slist
+                critPools[pool] = "Servers {0!s} are marked down but pooled".format(slist)
             elif total < (total * crd.lvsservice.getDepoolThreshold() + 1):
                 resp['status'] = 'warning'
-                resp['msg'] += "Pool %s is too small to allow depooling. " % crd.lvsservice.name
+                resp['msg'] += "Pool {0!s} is too small to allow depooling. ".format(crd.lvsservice.name)
         if critPools != {}:
             resp['status'] = 'critical'
-            resp['msg'] = "; ".join(["%s: %s" % (k, v)
+            resp['msg'] = "; ".join(["{0!s}: {1!s}".format(k, v)
                                     for k, v in critPools.items()])
 
         if resp['status'] == 'ok':
@@ -77,7 +77,7 @@ class Alerts(Resource):
         if wantJson(request):
             return json.dumps(resp)
         else:
-            return "%s - %s" % (resp['status'].upper(), resp['msg'])
+            return "{0!s} - {1!s}".format(resp['status'].upper(), resp['msg'])
 
 class PoolsRoot(Resource):
     """Pools base resource.

--- a/pybal/ipvs.py
+++ b/pybal/ipvs.py
@@ -55,10 +55,10 @@ class IPVSManager(object):
 
         if ':' in service[1]:
             # IPv6 address
-            service = ' [%s]:%d' % service[1:3]
+            service = ' [{0!s}]:{1:d}'.format(*service[1:3])
         else:
             # IPv4
-            service = ' %s:%d' % service[1:3]
+            service = ' {0!s}:{1:d}'.format(*service[1:3])
 
         return protocol + service
 
@@ -72,7 +72,7 @@ class IPVSManager(object):
             server:    PyBal server object
         """
 
-        return '-r %s' % (server.ip or server.host)
+        return '-r {0!s}'.format((server.ip or server.host))
 
     @staticmethod
     def commandClearServiceTable():
@@ -127,7 +127,7 @@ class IPVSManager(object):
 
         # Include weight if specified
         if server.weight:
-            cmd += ' -w %d' % server.weight
+            cmd += ' -w {0:d}'.format(server.weight)
 
         return cmd
 
@@ -146,7 +146,7 @@ class IPVSManager(object):
 
         # Include weight if specified
         if server.weight:
-            cmd += ' -w %d' % server.weight
+            cmd += ' -w {0:d}'.format(server.weight)
 
         return cmd
 

--- a/pybal/monitor.py
+++ b/pybal/monitor.py
@@ -66,28 +66,28 @@ class MonitoringProtocol(object):
 
     def report(self, text, level=logging.DEBUG):
         """Common method for reporting/logging check results."""
-        msg = "%s (%s): %s" % (
+        msg = "{0!s} ({1!s}): {2!s}".format(
             self.server.host,
             self.server.textStatus(),
             text
         )
-        s = "%s %s" % (self.server.lvsservice.name, self.__name__)
+        s = "{0!s} {1!s}".format(self.server.lvsservice.name, self.__name__)
         _log(msg, level, s)
 
     def _getConfigBool(self, optionname, default=None):
         return self.configuration.getboolean(
-            '%s.%s' % (self.__name__.lower(), optionname), default)
+            '{0!s}.{1!s}'.format(self.__name__.lower(), optionname), default)
 
     def _getConfigInt(self, optionname, default=None):
         return self.configuration.getint(
-            '%s.%s' % (self.__name__.lower(), optionname), default)
+            '{0!s}.{1!s}'.format(self.__name__.lower(), optionname), default)
 
     def _getConfigString(self, optionname):
         val = self.configuration[self.__name__.lower() + '.' + optionname]
         if type(val) == str:
             return val
         else:
-            raise ValueError("Value of %s is not a string" % optionname)
+            raise ValueError("Value of {0!s} is not a string".format(optionname))
 
     def _getConfigStringList(self, optionname, locals=None, globals=None):
         """Takes a (string) value, eval()s it and checks whether it
@@ -103,5 +103,5 @@ class MonitoringProtocol(object):
             # empty.
             return val
         else:
-            raise ValueError("Value of %s is not a string or stringlist" %
-                             optionname)
+            raise ValueError("Value of {0!s} is not a string or stringlist".format(
+                             optionname))

--- a/pybal/monitors/dnsquery.py
+++ b/pybal/monitors/dnsquery.py
@@ -92,11 +92,11 @@ class DNSQueryMonitoringProtocol(monitor.MonitoringProtocol):
             addresses = " ".join([socket.inet_ntop(addressFamily, r.payload.address)
                                   for r in answers
                                   if r.type == query.type])
-            resultStr = "%s %s %s" % (query.name, dns.QUERY_TYPES[query.type], addresses)
+            resultStr = "{0!s} {1!s} {2!s}".format(query.name, dns.QUERY_TYPES[query.type], addresses)
         else:
             resultStr = None
 
-        self.report('DNS query successful, %.3f s' % (runtime.seconds() - self.checkStartTime)
+        self.report('DNS query successful, {0:.3f} s'.format((runtime.seconds() - self.checkStartTime))
                     + (resultStr and (': ' + resultStr) or ""))
         self._resultUp()
 
@@ -105,7 +105,7 @@ class DNSQueryMonitoringProtocol(monitor.MonitoringProtocol):
     def _queryFailed(self, failure, query):
         """Called when the DNS query finished with a failure."""
 
-        queryStr = ", query: %s %s" % (query.name, dns.QUERY_TYPES[query.type])
+        queryStr = ", query: {0!s} {1!s}".format(query.name, dns.QUERY_TYPES[query.type])
 
         # Don't act as if the check failed if we cancelled it
         if failure.check(defer.CancelledError):
@@ -115,7 +115,7 @@ class DNSQueryMonitoringProtocol(monitor.MonitoringProtocol):
         elif failure.check(error.DNSServerError):
             errorStr = "DNS server error" + queryStr
         elif failure.check(error.DNSNameError):
-            errorStr = "%s NXDOMAIN" % query.name
+            errorStr = "{0!s} NXDOMAIN".format(query.name)
             if not self.failOnNXDOMAIN:
                 self.report(errorStr, level=logging.INFO)
                 self._resultUp()
@@ -126,7 +126,7 @@ class DNSQueryMonitoringProtocol(monitor.MonitoringProtocol):
             errorStr = str(failure)
 
         self.report(
-            'DNS query failed, %.3f s' % (runtime.seconds() - self.checkStartTime),
+            'DNS query failed, {0:.3f} s'.format((runtime.seconds() - self.checkStartTime)),
             level=logging.ERROR
         )
 

--- a/pybal/monitors/proxyfetch.py
+++ b/pybal/monitors/proxyfetch.py
@@ -115,7 +115,7 @@ class ProxyFetchMonitoringProtocol(monitor.MonitoringProtocol):
     def _fetchSuccessful(self, result):
         """Called when getProxyPage is finished successfully."""
 
-        self.report('Fetch successful, %.3f s' % (seconds() - self.checkStartTime))
+        self.report('Fetch successful, {0:.3f} s'.format((seconds() - self.checkStartTime)))
         self._resultUp()
 
         return result
@@ -127,7 +127,7 @@ class ProxyFetchMonitoringProtocol(monitor.MonitoringProtocol):
         if failure.check(defer.CancelledError):
             return None
 
-        self.report('Fetch failed, %.3f s' % (seconds() - self.checkStartTime),
+        self.report('Fetch failed, {0:.3f} s'.format((seconds() - self.checkStartTime)),
                     level=logging.WARN)
 
         self._resultDown(failure.getErrorMessage())

--- a/pybal/pybal.py
+++ b/pybal/pybal.py
@@ -227,7 +227,7 @@ class Server:
         return reduce(lambda b,monitor: b or monitor.up, self.monitors, len(self.monitors) == 0)
 
     def textStatus(self):
-        return "%s/%s/%s" % (self.enabled and "enabled" or "disabled",
+        return "{0!s}/{1!s}/{2!s}".format(self.enabled and "enabled" or "disabled",
                              self.up and "up" or (self.calcPartialStatus() and "partially up" or "down"),
                              self.pooled and "pooled" or "not pooled")
 
@@ -295,7 +295,7 @@ class Coordinator:
         self.configObserver.startObserving()
 
     def __str__(self):
-        return "[%s]" % self.lvsservice.name
+        return "[{0!s}]".format(self.lvsservice.name)
 
     def assignServers(self):
         """

--- a/pybal/test/test_instrumentation.py
+++ b/pybal/test/test_instrumentation.py
@@ -31,13 +31,13 @@ class WebBaseTestCase(PyBalTestCase):
         self.coordinators = []
         for i in xrange(3):
             lvsservice = mock.MagicMock()
-            lvsservice.name = 'test_pool%d' % i
+            lvsservice.name = 'test_pool{0:d}'.format(i)
             coord = mock.MagicMock()
             coord.servers = {}
             coord.lvsservice = lvsservice
             for j in xrange(1, 11):
-                host = "mw10%02d" % j
-                ip = '192.168.10.%d' % j
+                host = "mw10{0:02d}".format(j)
+                ip = '192.168.10.{0:d}'.format(j)
                 port = 80
                 weight = 10
                 s = ServerStub(host, ip=ip, port=port, weight=weight,

--- a/pybal/test/test_ipvs.py
+++ b/pybal/test/test_ipvs.py
@@ -153,8 +153,8 @@ class LVSServiceTestCase(PyBalTestCase):
         lvs_service.assignServers(new_servers)
         self.assertEquals(
             sorted(lvs_service.ipvsManager.cmdList),
-            ['-a -t 127.0.0.1:80 -r %s' % s for s in 'cde'] +
-            ['-d -t 127.0.0.1:80 -r %s' % s for s in 'abc']
+            ['-a -t 127.0.0.1:80 -r {0!s}'.format(s) for s in 'cde'] +
+            ['-d -t 127.0.0.1:80 -r {0!s}'.format(s) for s in 'abc']
         )
 
     def testAddServer(self):

--- a/pybal/util.py
+++ b/pybal/util.py
@@ -110,7 +110,7 @@ class Logger(object):
         def _log(msg, **kwargs):
             level = Logger._to_str(lvl)
             sys = kwargs.get('system', 'pybal')
-            message = "%s: %s" % (level, msg)
+            message = "{0!s}: {1!s}".format(level, msg)
             tw_log.msg(message, logLevel=lvl, system=sys)
         return _log
 

--- a/pybal/version.py
+++ b/pybal/version.py
@@ -11,4 +11,4 @@ __all__ = ('__version__', 'USER_AGENT_STRING')
 
 __version__ = '1.6'
 
-USER_AGENT_STRING = 'PyBal/%s' % __version__
+USER_AGENT_STRING = 'PyBal/{0!s}'.format(__version__)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:PyBal?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:PyBal?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
